### PR TITLE
fix: use v4 artifact action in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,14 +41,10 @@ jobs:
     - name: Build app
       run: make build
 
-    # - name: Upload GitHub Pages artifact
-    #   uses: actions/upload-artifact@v4
-    #   with:
-    #     name: github-pages
-    #     path: dist
-
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v4
+      with:
+        path: dist
 
   deploy:
 


### PR DESCRIPTION
## Summary
- update workflow to use `actions/upload-pages-artifact@v4`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: src/components/pages/Posts.tsx:1:1 and src/posts/boids.tsx:2:8: error TS6133: 'React' is declared but its value is never read.)*

------
https://chatgpt.com/codex/tasks/task_e_689cf21370d4833185fbaf25251ab515