### PR TITLE
fix: use v3 upload-pages artifact in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,14 +41,10 @@ jobs:
     - name: Build app
       run: make build
 
-    # - name: Upload GitHub Pages artifact
-    #   uses: actions/upload-artifact@v4
-    #   with:
-    #     name: github-pages
-    #     path: dist
-
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: dist
 
   deploy:
 


### PR DESCRIPTION
## Summary
- adjust deploy workflow to use `actions/upload-pages-artifact@v3`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: 'React' is declared but its value is never read in Posts.tsx and boids.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689cf21370d4833185fbaf25251ab515