### PR TITLE
chore: remove unused React imports

### DIFF
--- a/src/components/pages/Posts.tsx
+++ b/src/components/pages/Posts.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router-dom';
 import posts from '@/posts';
 

--- a/src/posts/boids.tsx
+++ b/src/posts/boids.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-refresh/only-export-components */
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import PostPage from './PostPage';
 import thumb from '@/assets/boids-thumb.svg';
 


### PR DESCRIPTION
## Summary
- remove unused React import from Posts page
- remove unused default React import from Boids post

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d4237bb5483319ba4e272e26b3ad3