### PR TITLE
Fix GitHub Pages artifact path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
       uses: actions/upload-pages-artifact@v3
 
       with:
-        path: dist
+        path: _site
 
   deploy:
 


### PR DESCRIPTION
## Summary
- fix GitHub Pages workflow to upload build output from `_site`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d4418339c8331aec24100ce8c494f