### PR TITLE
fix: allow deploy pages to access build artifact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  actions: read
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -57,13 +58,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
 
-    permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
-
-
     steps:
-    - name: Configure GitHub Pages
-      uses: actions/configure-pages@v3
     - name: Deploy to GitHub Pages
+      id: deployment
       uses: actions/deploy-pages@v2


### PR DESCRIPTION
## Summary
- grant actions read permission so deploy-pages can fetch build artifacts
- simplify deploy job and expose deployment URL

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d457a519c8331beb8cca11ce506dc